### PR TITLE
build(identity): remove @ethersproject dependencies in identity `src/`

### DIFF
--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -32,10 +32,6 @@
         "typedoc": "^0.22.11"
     },
     "dependencies": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/random": "^5.5.1",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
         "circomlibjs": "0.0.8"
     }
 }

--- a/packages/identity/src/identity.test.ts
+++ b/packages/identity/src/identity.test.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from "@ethersproject/bignumber"
 import Identity from "./identity"
 
 describe("Identity", () => {
@@ -44,7 +43,7 @@ describe("Identity", () => {
         it("Should not recreate an existing invalid identity", () => {
             const fun = () => new Identity('[true, "01323"]')
 
-            expect(fun).toThrow("invalid BigNumber string")
+            expect(fun).toThrow("Cannot convert 0xtrue to a BigInt")
         })
 
         it("Should recreate an existing identity", () => {
@@ -107,8 +106,8 @@ describe("Identity", () => {
 
             const [trapdoor, nullifier] = JSON.parse(identity.toString())
 
-            expect(BigNumber.from(`0x${trapdoor}`).toBigInt()).toBe(identity.getTrapdoor())
-            expect(BigNumber.from(`0x${nullifier}`).toBigInt()).toBe(identity.getNullifier())
+            expect(BigInt(`0x${trapdoor}`)).toBe(identity.getTrapdoor())
+            expect(BigInt(`0x${nullifier}`)).toBe(identity.getNullifier())
         })
     })
 })

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from "@ethersproject/bignumber"
 import { poseidon } from "circomlibjs"
 import checkParameter from "./checkParameter"
 import { genRandomNumber, isJsonArray, sha256 } from "./utils"
@@ -24,16 +23,16 @@ export default class Identity {
         if (!isJsonArray(identityOrMessage)) {
             const messageHash = sha256(identityOrMessage).slice(2)
 
-            this._trapdoor = BigNumber.from(sha256(`${messageHash}identity_trapdoor`)).toBigInt()
-            this._nullifier = BigNumber.from(sha256(`${messageHash}identity_nullifier`)).toBigInt()
+            this._trapdoor = BigInt(sha256(`${messageHash}identity_trapdoor`))
+            this._nullifier = BigInt(sha256(`${messageHash}identity_nullifier`))
 
             return
         }
 
         const [trapdoor, nullifier] = JSON.parse(identityOrMessage)
 
-        this._trapdoor = BigNumber.from(`0x${trapdoor}`).toBigInt()
-        this._nullifier = BigNumber.from(`0x${nullifier}`).toBigInt()
+        this._trapdoor = BigInt(`0x${trapdoor}`)
+        this._nullifier = BigInt(`0x${nullifier}`)
     }
 
     /**

--- a/packages/identity/src/utils.ts
+++ b/packages/identity/src/utils.ts
@@ -1,7 +1,4 @@
-import { BigNumber } from "@ethersproject/bignumber"
-import { randomBytes } from "@ethersproject/random"
-import { sha256 as _sha256 } from "@ethersproject/sha2"
-import { toUtf8Bytes } from "@ethersproject/strings"
+import { createHash, randomBytes } from "crypto"
 
 /**
  * Returns an hexadecimal sha256 hash of the message passed as parameter.
@@ -9,9 +6,7 @@ import { toUtf8Bytes } from "@ethersproject/strings"
  * @returns The hexadecimal hash of the message.
  */
 export function sha256(message: string): string {
-    const hash = _sha256(toUtf8Bytes(message))
-
-    return hash
+    return `0x${  createHash("sha256").update(Buffer.from(message)).digest("hex")}`
 }
 
 /**
@@ -20,7 +15,7 @@ export function sha256(message: string): string {
  * @returns The generated random number.
  */
 export function genRandomNumber(numberOfBytes = 31): bigint {
-    return BigNumber.from(randomBytes(numberOfBytes)).toBigInt()
+    return BigInt(`0x${  randomBytes(numberOfBytes).toString("hex")}`)
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,7 +1669,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/bignumber@npm:^5.0.7, @ethersproject/bignumber@npm:^5.5.0, @ethersproject/bignumber@npm:^5.6.2":
+"@ethersproject/bignumber@npm:^5.0.7, @ethersproject/bignumber@npm:^5.6.2":
   version: 5.6.2
   resolution: "@ethersproject/bignumber@npm:5.6.2"
   dependencies:
@@ -1746,16 +1746,6 @@ __metadata:
   dependencies:
     "@ethersproject/logger": ^5.6.0
   checksum: adcb6a843dcdf809262d77d6fbe52acdd48703327b298f78e698b76784e89564fb81791d27eaee72b1a6aaaf5688ea2ae7a95faabdef8b4aecc99989fec55901
-  languageName: node
-  linkType: hard
-
-"@ethersproject/random@npm:^5.5.1":
-  version: 5.6.1
-  resolution: "@ethersproject/random@npm:5.6.1"
-  dependencies:
-    "@ethersproject/bytes": ^5.6.1
-    "@ethersproject/logger": ^5.6.0
-  checksum: 55517d65eee6dcc0848ef10a825245d61553a6c1bec15d2f69d9430ce4568d9af32013e2aa96c8336545465a24a1fd04defbe9e9f76a5ee110dc5128d4111c11
   languageName: node
   linkType: hard
 
@@ -2262,10 +2252,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@semaphore-protocol/identity@workspace:packages/identity"
   dependencies:
-    "@ethersproject/bignumber": ^5.5.0
-    "@ethersproject/random": ^5.5.1
-    "@ethersproject/sha2": ^5.6.1
-    "@ethersproject/strings": ^5.6.1
     circomlibjs: 0.0.8
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Use built-in `crypto` package to compute identity
Remove `@ethersproject` dependencies in identity package

I aslo test few `sha256` hashes in utils and `sha256` hashes in `@ethersproject/sha2`, and they are the same

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
