### PR TITLE
New @semaphore-protocol/subgraph library

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,30 @@
                 </a>
             </td>
         </tr>
+        <tr>
+            <td>
+                <a href="https://github.com/semaphore-protocol/semaphore.js/tree/main/packages/subgraph">
+                    @semaphore-protocol/subgraph
+                </a>
+                <a href="https://semaphore-protocol.github.io/semaphore.js/subgraph">
+                    (docs)
+                </a>
+            </td>
+            <td>
+                <!-- NPM version -->
+                <a href="https://npmjs.org/package/@semaphore-protocol/subgraph">
+                    <img src="https://img.shields.io/npm/v/@semaphore-protocol/subgraph.svg?style=flat-square" alt="NPM version" />
+                </a>
+            </td>
+            <td>
+                <!-- Downloads -->
+                <a href="https://npmjs.org/package/@semaphore-protocol/subgraph">
+                    <img src="https://img.shields.io/npm/dm/@semaphore-protocol/subgraph.svg?style=flat-square" alt="Downloads" />
+                </a>
+            </td>
+        </tr>
     <tbody>
+
 </table>
 
 ## 🛠 Install

--- a/packages/subgraph/LICENSE
+++ b/packages/subgraph/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Ethereum Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/subgraph/README.md
+++ b/packages/subgraph/README.md
@@ -1,0 +1,88 @@
+<p align="center">
+    <h1 align="center">
+        Semaphore subgraph
+    </h1>
+    <p align="center">A library to query Semaphore contracts.</p>
+</p>
+
+<p align="center">
+    <a href="https://github.com/semaphore-protocol/semaphore.js">
+        <img src="https://img.shields.io/badge/project-semaphore-blue.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/semaphore-protocol/semaphore.js/blob/main/packages/subgraph/LICENSE">
+        <img alt="Github license" src="https://img.shields.io/github/license/semaphore-protocol/semaphore.js.svg?style=flat-square">
+    </a>
+    <a href="https://www.npmjs.com/package/@semaphore-protocol/subgraph">
+        <img alt="NPM version" src="https://img.shields.io/npm/v/@semaphore-protocol/subgraph?style=flat-square" />
+    </a>
+    <a href="https://npmjs.org/package/@semaphore-protocol/subgraph">
+        <img alt="Downloads" src="https://img.shields.io/npm/dm/@semaphore-protocol/subgraph.svg?style=flat-square" />
+    </a>
+    <a href="https://eslint.org/">
+        <img alt="Linter eslint" src="https://img.shields.io/badge/linter-eslint-8080f2?style=flat-square&logo=eslint" />
+    </a>
+    <a href="https://prettier.io/">
+        <img alt="Code style prettier" src="https://img.shields.io/badge/code%20style-prettier-f8bc45?style=flat-square&logo=prettier" />
+    </a>
+</p>
+
+<div align="center">
+    <h4>
+        <a href="https://t.me/joinchat/B-PQx1U3GtAh--Z4Fwo56A">
+            🗣️ Chat &amp; Support
+        </a>
+        <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+        <a href="https://semaphore-protocol.github.io/semaphore.js/subgraph">
+            📘 Docs
+        </a>
+    </h4>
+</div>
+
+| This library allows you to query the [`Semaphore.sol`](https://github.com/semaphore-protocol/semaphore/blob/main/contracts/Semaphore.sol) contract data (i.e. groups) using the [Semaphore subgraph](https://github.com/semaphore-protocol/subgraph) on Kovan, Goerli, and Arbitrum One. It can be used on Node.js and browsers. |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+
+## 🛠 Install
+
+### npm or yarn
+
+Install the `@semaphore-protocol/subgraph` package with npm:
+
+```bash
+npm i @semaphore-protocol/subgraph
+```
+
+or yarn:
+
+```bash
+yarn add @semaphore-protocol/subgraph
+```
+
+## 📜 Usage
+
+\# **new Subgraph**(network: _Network_ = "arbitrum" ): _Subgraph_
+
+```typescript
+import { Subgraph } from "@semaphore-protocol/subgraph"
+
+const subgraph = new Subgraph()
+```
+
+\# **getGroups**(options?: _{ members: boolean }_)
+
+```typescript
+const groups = subgraph.getGroups()
+
+// or
+
+const groups = subgraph.getGroups({ members: true })
+```
+
+\# **getGroup**(groupId: _string_, options?: _{ members: boolean }_)
+
+```typescript
+const group = subgraph.getGroup("1")
+
+// or
+
+const { members } = subgraph.getGroup("1", { members: true })
+```

--- a/packages/subgraph/build.tsconfig.json
+++ b/packages/subgraph/build.tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "declarationDir": "dist/types"
+    },
+    "include": ["src"]
+}

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@semaphore-protocol/subgraph",
+    "version": "0.1.0",
+    "description": "A library to query Semaphore contracts.",
+    "license": "MIT",
+    "iife": "dist/index.js",
+    "unpkg": "dist/index.min.js",
+    "jsdelivr": "dist/index.min.js",
+    "main": "dist/index.node.js",
+    "exports": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.node.js"
+    },
+    "types": "dist/types/index.d.ts",
+    "files": [
+        "dist/",
+        "src/",
+        "LICENSE",
+        "README.md"
+    ],
+    "repository": "https://github.com/semaphore-protocol/semaphore.js",
+    "homepage": "https://github.com/semaphore-protocol/semaphore.js/tree/main/packages/subgraph",
+    "scripts": {
+        "build:watch": "rollup -c rollup.config.ts -w --configPlugin typescript",
+        "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin typescript",
+        "prepublishOnly": "yarn build",
+        "docs": "typedoc src/index.ts --out ../../docs/subgraph"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "devDependencies": {
+        "rollup-plugin-cleanup": "^3.2.1",
+        "rollup-plugin-terser": "^7.0.2",
+        "rollup-plugin-typescript2": "^0.31.2",
+        "typedoc": "^0.22.11"
+    },
+    "dependencies": {
+        "axios": "^0.27.2"
+    }
+}

--- a/packages/subgraph/rollup.config.ts
+++ b/packages/subgraph/rollup.config.ts
@@ -1,0 +1,42 @@
+import * as fs from "fs"
+import cleanup from "rollup-plugin-cleanup"
+import { terser } from "rollup-plugin-terser"
+import typescript from "rollup-plugin-typescript2"
+
+const pkg = JSON.parse(fs.readFileSync("./package.json", "utf-8"))
+const name = pkg.name.substr(1).replace(/[-/]./g, (x: string) => x.toUpperCase()[1])
+const banner = `/**
+ * @module ${pkg.name}
+ * @version ${pkg.version}
+ * @file ${pkg.description}
+ * @copyright Ethereum Foundation 2022
+ * @license ${pkg.license}
+ * @see [Github]{@link ${pkg.homepage}}
+*/`
+
+export default {
+    input: "src/index.ts",
+    output: [
+        {
+            file: pkg.iife,
+            name,
+            format: "iife",
+            globals: { axios: "axios" },
+            banner
+        },
+        {
+            file: pkg.unpkg,
+            name,
+            format: "iife",
+            globals: { axios: "axios" },
+            plugins: [terser({ output: { preamble: banner } })]
+        },
+        { file: pkg.exports.require, format: "cjs", banner, exports: "auto" },
+        { file: pkg.exports.import, format: "es", banner }
+    ],
+    external: Object.keys(pkg.dependencies),
+    plugins: [
+        typescript({ tsconfig: "./build.tsconfig.json", useTsconfigDeclarationDir: true }),
+        cleanup({ comments: "jsdoc" })
+    ]
+}

--- a/packages/subgraph/src/checkParameter.ts
+++ b/packages/subgraph/src/checkParameter.ts
@@ -1,0 +1,5 @@
+export default function checkParameter(value: any, name: string, type: string) {
+    if (typeof value !== type) {
+        throw new TypeError(`Parameter '${name}' is not ${type === "object" ? "an" : "a"} ${type}`)
+    }
+}

--- a/packages/subgraph/src/getURL.ts
+++ b/packages/subgraph/src/getURL.ts
@@ -1,0 +1,12 @@
+import { Network } from "./types"
+
+export default function getURL(network: Network): string {
+    switch (network) {
+        case "kovan":
+        case "goerli":
+        case "arbitrum":
+            return `https://api.thegraph.com/subgraphs/name/semaphore-protocol/${network}`
+        default:
+            throw new TypeError(`Network '${network}' is not supported`)
+    }
+}

--- a/packages/subgraph/src/index.ts
+++ b/packages/subgraph/src/index.ts
@@ -1,0 +1,4 @@
+import Subgraph from "./subgraph"
+
+export { Subgraph }
+export * from "./types"

--- a/packages/subgraph/src/request.ts
+++ b/packages/subgraph/src/request.ts
@@ -1,0 +1,8 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios"
+
+/* istanbul ignore next */
+export default async function request(url: string, config?: AxiosRequestConfig): Promise<any> {
+    const { data }: AxiosResponse<any> = await axios(url, config)
+
+    return data?.data
+}

--- a/packages/subgraph/src/subgraph.test.ts
+++ b/packages/subgraph/src/subgraph.test.ts
@@ -1,0 +1,200 @@
+import request from "./request"
+import Subgraph from "./subgraph"
+
+jest.mock("./request", () => ({
+    __esModule: true,
+    default: jest.fn()
+}))
+
+const requestMocked = request as jest.MockedFunction<typeof request>
+
+describe("Subgraph", () => {
+    let subgraph: Subgraph
+
+    describe("# Subgraph", () => {
+        it("Should instantiate a subgraph object", () => {
+            const subgraph1 = new Subgraph("kovan")
+            const subgraph2 = new Subgraph("goerli")
+
+            subgraph = new Subgraph()
+
+            expect(subgraph1.url).toContain("kovan")
+            expect(subgraph2.url).toContain("goerli")
+            expect(subgraph.url).toContain("arbitrum")
+        })
+
+        it("Should throw an error if there is a wrong network", () => {
+            const fun = () => new Subgraph("wrong" as any)
+
+            expect(fun).toThrow("Network 'wrong' is not supported")
+        })
+
+        it("Should throw an error if the network parameter type is wrong", () => {
+            const fun = () => new Subgraph(33 as any)
+
+            expect(fun).toThrow("Parameter 'network' is not a string")
+        })
+    })
+
+    describe("# getGroups", () => {
+        it("Should return all the existing groups", async () => {
+            requestMocked.mockImplementationOnce(() =>
+                Promise.resolve({
+                    groups: [
+                        {
+                            id: "1",
+                            depth: 20,
+                            zeroValue: 0,
+                            size: 2,
+                            numberOfLeaves: 2,
+                            root: "2",
+                            admin: "0x7bcd6f009471e9974a77086a69289d16eadba286"
+                        }
+                    ]
+                })
+            )
+
+            const expectedValue = await subgraph.getGroups()
+
+            expect(expectedValue).toBeDefined()
+            expect(Array.isArray(expectedValue)).toBeTruthy()
+            expect(expectedValue).toContainEqual({
+                id: "1",
+                depth: 20,
+                zeroValue: 0,
+                size: 2,
+                numberOfLeaves: 2,
+                root: "2",
+                admin: "0x7bcd6f009471e9974a77086a69289d16eadba286"
+            })
+        })
+
+        it("Should throw an error if the options parameter type is wrong", async () => {
+            const fun = () => subgraph.getGroups(1 as any)
+
+            await expect(fun).rejects.toThrow("Parameter 'options' is not an object")
+        })
+
+        it("Should return all the existing groups with their members", async () => {
+            requestMocked.mockImplementationOnce(() =>
+                Promise.resolve({
+                    groups: [
+                        {
+                            id: "1",
+                            depth: 20,
+                            zeroValue: 0,
+                            size: 2,
+                            numberOfLeaves: 2,
+                            root: "2",
+                            admin: "0x7bcd6f009471e9974a77086a69289d16eadba286",
+                            members: [
+                                {
+                                    identityCommitment: "1"
+                                },
+                                {
+                                    identityCommitment: "2"
+                                }
+                            ]
+                        }
+                    ]
+                })
+            )
+
+            const expectedValue = await subgraph.getGroups({ members: true })
+
+            expect(expectedValue).toBeDefined()
+            expect(Array.isArray(expectedValue)).toBeTruthy()
+            expect(expectedValue).toContainEqual({
+                id: "1",
+                depth: 20,
+                zeroValue: 0,
+                size: 2,
+                numberOfLeaves: 2,
+                root: "2",
+                admin: "0x7bcd6f009471e9974a77086a69289d16eadba286",
+                members: ["1", "2"]
+            })
+        })
+    })
+
+    describe("# getGroup", () => {
+        it("Should return a specific group", async () => {
+            requestMocked.mockImplementationOnce(() =>
+                Promise.resolve({
+                    groups: [
+                        {
+                            id: "1",
+                            depth: 20,
+                            zeroValue: 0,
+                            size: 2,
+                            numberOfLeaves: 2,
+                            root: "2",
+                            admin: "0x7bcd6f009471e9974a77086a69289d16eadba286"
+                        }
+                    ]
+                })
+            )
+
+            const expectedValue = await subgraph.getGroup("1")
+
+            expect(expectedValue).toBeDefined()
+            expect(expectedValue).toEqual({
+                id: "1",
+                depth: 20,
+                zeroValue: 0,
+                size: 2,
+                numberOfLeaves: 2,
+                root: "2",
+                admin: "0x7bcd6f009471e9974a77086a69289d16eadba286"
+            })
+        })
+
+        it("Should throw an error if the options parameter type is wrong", async () => {
+            const fun = () => subgraph.getGroup("1", 1 as any)
+
+            await expect(fun).rejects.toThrow("Parameter 'options' is not an object")
+        })
+
+        it("Should return a specific group with its members", async () => {
+            requestMocked.mockImplementationOnce(() =>
+                Promise.resolve({
+                    groups: [
+                        {
+                            id: "1",
+                            depth: 20,
+                            zeroValue: 0,
+                            size: 2,
+                            numberOfLeaves: 2,
+                            root: "2",
+                            admin: "0x7bcd6f009471e9974a77086a69289d16eadba286",
+                            members: [
+                                {
+                                    identityCommitment: "1"
+                                },
+                                {
+                                    identityCommitment: "2"
+                                }
+                            ]
+                        }
+                    ]
+                })
+            )
+
+            const expectedValue = await subgraph.getGroup("1", {
+                members: true
+            })
+
+            expect(expectedValue).toBeDefined()
+            expect(expectedValue).toEqual({
+                id: "1",
+                depth: 20,
+                zeroValue: 0,
+                size: 2,
+                numberOfLeaves: 2,
+                root: "2",
+                admin: "0x7bcd6f009471e9974a77086a69289d16eadba286",
+                members: ["1", "2"]
+            })
+        })
+    })
+})

--- a/packages/subgraph/src/subgraph.ts
+++ b/packages/subgraph/src/subgraph.ts
@@ -1,0 +1,102 @@
+import { AxiosRequestConfig } from "axios"
+import checkParameter from "./checkParameter"
+import getURL from "./getURL"
+import request from "./request"
+import { Network } from "./types"
+
+export default class Subgraph {
+    private _url: string
+
+    constructor(network: Network = "arbitrum") {
+        checkParameter(network, "network", "string")
+
+        this._url = getURL(network)
+    }
+
+    get url(): string {
+        return this._url
+    }
+
+    async getGroups(options: { members?: boolean } = {}): Promise<any[]> {
+        checkParameter(options, "options", "object")
+
+        const { members = false } = options
+
+        checkParameter(members, "members", "boolean")
+
+        const config: AxiosRequestConfig = {
+            method: "post",
+            data: JSON.stringify({
+                query: `{
+                    groups {
+                        id
+                        depth
+                        zeroValue
+                        root
+                        size
+                        numberOfLeaves
+                        admin
+                        ${
+                            members === true
+                                ? `members(orderBy: index) {
+                            identityCommitment
+                        }`
+                                : ""
+                        }
+                    }
+                }`
+            })
+        }
+
+        const { groups } = await request(this._url, config)
+
+        if (members) {
+            for (const group of groups) {
+                group.members = group.members.map((member: any) => member.identityCommitment)
+            }
+        }
+
+        return groups
+    }
+
+    async getGroup(groupId: string, options: { members?: boolean } = {}): Promise<any> {
+        checkParameter(groupId, "groupId", "string")
+        checkParameter(options, "options", "object")
+
+        const { members = false } = options
+
+        checkParameter(members, "members", "boolean")
+
+        const config: AxiosRequestConfig = {
+            method: "post",
+            data: JSON.stringify({
+                query: `{
+                    groups(where: { id: "${groupId}" }) {
+                        id
+                        depth
+                        zeroValue
+                        root
+                        size
+                        numberOfLeaves
+                        admin
+                        ${
+                            members === true
+                                ? `members(orderBy: index) {
+                            identityCommitment
+                        }`
+                                : ""
+                        }
+                    }
+                }`
+            })
+        }
+
+        const { groups } = await request(this._url, config)
+
+        if (members) {
+            groups[0].members = groups[0].members.map((member: any) => member.identityCommitment)
+        }
+
+        return groups[0]
+    }
+}

--- a/packages/subgraph/src/types/index.ts
+++ b/packages/subgraph/src/types/index.ts
@@ -1,0 +1,1 @@
+export type Network = "kovan" | "goerli" | "arbitrum"

--- a/packages/subgraph/tsconfig.json
+++ b/packages/subgraph/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["src", "rollup.config.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.10.4":
+  version: 7.18.6
+  resolution: "@babel/code-frame@npm:7.18.6"
+  dependencies:
+    "@babel/highlight": ^7.18.6
+  checksum: 195e2be3172d7684bf95cff69ae3b7a15a9841ea9d27d3c843662d50cdd7d6470fd9c8e64be84d031117e4a4083486effba39f9aef6bbb2c89f7f21bcfba33ba
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.17.10":
   version: 7.17.10
   resolution: "@babel/compat-data@npm:7.17.10"
@@ -288,6 +297,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-validator-identifier@npm:7.18.6"
+  checksum: e295254d616bbe26e48c196a198476ab4d42a73b90478c9842536cf910ead887f5af6b5c4df544d3052a25ccb3614866fa808dc1e3a5a4291acd444e243c0648
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/helper-validator-option@npm:7.16.7"
@@ -326,6 +342,17 @@ __metadata:
     chalk: ^2.0.0
     js-tokens: ^4.0.0
   checksum: 841a11aa353113bcce662b47085085a379251bf8b09054e37e1e082da1bf0d59355a556192a6b5e9ee98e8ee6f1f2831ac42510633c5e7043e3744dda2d6b9d6
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/highlight@npm:7.18.6"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.18.6
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
   languageName: node
   linkType: hard
 
@@ -2147,6 +2174,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/source-map@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@jridgewell/source-map@npm:0.3.2"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.0
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: 1b83f0eb944e77b70559a394d5d3b3f98a81fcc186946aceb3ef42d036762b52ef71493c6c0a3b7c1d2f08785f53ba2df1277fe629a06e6109588ff4cdcf7482
+  languageName: node
+  linkType: hard
+
 "@jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.13
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.13"
@@ -2301,6 +2338,18 @@ __metadata:
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2
     snarkjs: ^0.4.13
+    typedoc: ^0.22.11
+  languageName: unknown
+  linkType: soft
+
+"@semaphore-protocol/subgraph@workspace:packages/subgraph":
+  version: 0.0.0-use.local
+  resolution: "@semaphore-protocol/subgraph@workspace:packages/subgraph"
+  dependencies:
+    axios: ^0.27.2
+    rollup-plugin-cleanup: ^3.2.1
+    rollup-plugin-terser: ^7.0.2
+    rollup-plugin-typescript2: ^0.31.2
     typedoc: ^0.22.11
   languageName: unknown
   linkType: soft
@@ -2902,6 +2951,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn@npm:^8.5.0":
+  version: 8.8.0
+  resolution: "acorn@npm:8.8.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 7270ca82b242eafe5687a11fea6e088c960af712683756abf0791b68855ea9cace3057bd5e998ffcef50c944810c1e0ca1da526d02b32110e13c722aa959afdc
+  languageName: node
+  linkType: hard
+
 "agent-base@npm:6, agent-base@npm:^6.0.2":
   version: 6.0.2
   resolution: "agent-base@npm:6.0.2"
@@ -3206,6 +3264,16 @@ __metadata:
   version: 1.11.0
   resolution: "aws4@npm:1.11.0"
   checksum: 5a00d045fd0385926d20ebebcfba5ec79d4482fe706f63c27b324d489a04c68edb0db99ed991e19eda09cb8c97dc2452059a34d97545cebf591d7a2b5a10999f
+  languageName: node
+  linkType: hard
+
+"axios@npm:^0.27.2":
+  version: 0.27.2
+  resolution: "axios@npm:0.27.2"
+  dependencies:
+    follow-redirects: ^1.14.9
+    form-data: ^4.0.0
+  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
   languageName: node
   linkType: hard
 
@@ -4089,7 +4157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.8.1":
+"commander@npm:^2.20.0, commander@npm:^2.8.1":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
@@ -5935,6 +6003,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.14.9":
+  version: 1.15.1
+  resolution: "follow-redirects@npm:1.15.1"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 6aa4e3e3cdfa3b9314801a1cd192ba756a53479d9d8cca65bf4db3a3e8834e62139245cd2f9566147c8dfe2efff1700d3e6aefd103de4004a7b99985e71dd533
+  languageName: node
+  linkType: hard
+
 "for-each@npm:^0.3.3":
   version: 0.3.3
   resolution: "for-each@npm:0.3.3"
@@ -5959,6 +6037,17 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: b019e8d35c8afc14a2bd8a7a92fa4f525a4726b6d5a9740e8d2623c30e308fbb58dc8469f90415a856698933c8479b01646a9dff33c87cc4e76d72aedbbf860d
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -7732,6 +7821,17 @@ __metadata:
     jest-util: ^27.5.1
     string-length: ^4.0.1
   checksum: 191c4e9c278c0902ade1a8a80883ac244963ba3e6e78607a3d5f729ccca9c6e71fb3b316f87883658132641c5d818aa84202585c76752e03c539e6cbecb820bd
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^26.2.1":
+  version: 26.6.2
+  resolution: "jest-worker@npm:26.6.2"
+  dependencies:
+    "@types/node": "*"
+    merge-stream: ^2.0.0
+    supports-color: ^7.0.0
+  checksum: f9afa3b88e3f12027901e4964ba3ff048285b5783b5225cab28fac25b4058cea8ad54001e9a1577ee2bed125fac3ccf5c80dc507b120300cc1bbcb368796533e
   languageName: node
   linkType: hard
 
@@ -10095,6 +10195,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup-plugin-terser@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "rollup-plugin-terser@npm:7.0.2"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    jest-worker: ^26.2.1
+    serialize-javascript: ^4.0.0
+    terser: ^5.0.0
+  peerDependencies:
+    rollup: ^2.0.0
+  checksum: af84bb7a7a894cd00852b6486528dfb8653cf94df4c126f95f389a346f401d054b08c46bee519a2ab6a22b33804d1d6ac6d8c90b1b2bf8fffb097eed73fc3c72
+  languageName: node
+  linkType: hard
+
 "rollup-plugin-typescript2@npm:^0.31.2":
   version: 0.31.2
   resolution: "rollup-plugin-typescript2@npm:0.31.2"
@@ -10325,6 +10439,15 @@ __metadata:
     range-parser: ~1.2.1
     statuses: 2.0.1
   checksum: 74fc07ebb58566b87b078ec63e5a3e41ecd987e4272ba67b7467e86c6ad51bc6b0b0154133b6d8b08a2ddda360464f71382f7ef864700f34844a76c8027817a8
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "serialize-javascript@npm:4.0.0"
+  dependencies:
+    randombytes: ^2.1.0
+  checksum: 3273b3394b951671fcf388726e9577021870dfbf85e742a1183fb2e91273e6101bdccea81ff230724f6659a7ee4cef924b0ff9baca32b79d9384ec37caf07302
   languageName: node
   linkType: hard
 
@@ -10577,7 +10700,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.6":
+"source-map-support@npm:^0.5.6, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -11035,6 +11158,20 @@ __metadata:
     ansi-escapes: ^4.2.1
     supports-hyperlinks: ^2.0.0
   checksum: ce3d2cd3a438c4a9453947aa664581519173ea40e77e2534d08c088ee6dda449eabdbe0a76d2a516b8b73c33262fedd10d5270ccf7576ae316e3db170ce6562f
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.0.0":
+  version: 5.14.2
+  resolution: "terser@npm:5.14.2"
+  dependencies:
+    "@jridgewell/source-map": ^0.3.2
+    acorn: ^8.5.0
+    commander: ^2.20.0
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: cabb50a640d6c2cfb351e4f43dc7bf7436f649755bb83eb78b2cacda426d5e0979bd44e6f92d713f3ca0f0866e322739b9ced888ebbce6508ad872d08de74fcc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

`@semaphore-protocol/subgraph` allows you to query the [`Semaphore.sol`](https://github.com/semaphore-protocol/semaphore/blob/main/contracts/Semaphore.sol) contract data (i.e. groups) using the [Semaphore subgraph](https://github.com/semaphore-protocol/subgraph) on Kovan, Goerli, and Arbitrum One. It can be used on Node.js and browsers.
## Related Issue

#5 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
