### PR TITLE
New method to update group members

### DIFF
--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -32,7 +32,7 @@
         "typedoc": "^0.22.11"
     },
     "dependencies": {
-        "@zk-kit/incremental-merkle-tree": "0.4.3",
+        "@zk-kit/incremental-merkle-tree": "1.0.0",
         "circomlibjs": "0.0.8"
     }
 }

--- a/packages/group/src/group.test.ts
+++ b/packages/group/src/group.test.ts
@@ -58,6 +58,18 @@ describe("Group", () => {
         })
     })
 
+    describe("# updateMember", () => {
+        it("Should update a member in a group", () => {
+            const group = new Group()
+            group.addMembers([BigInt(1), BigInt(3)])
+
+            group.updateMember(0, BigInt(1))
+
+            expect(group.members).toHaveLength(2)
+            expect(group.members[0]).toBe(BigInt(1))
+        })
+    })
+
     describe("# removeMember", () => {
         it("Should remove a member from a group", () => {
             const group = new Group()

--- a/packages/group/src/group.ts
+++ b/packages/group/src/group.ts
@@ -78,6 +78,15 @@ export default class Group {
     }
 
     /**
+     * Updates a member in the group.
+     * @param index Index of the member to be updated.
+     * @param identityCommitment New member value.
+     */
+    updateMember(index: number, identityCommitment: Member) {
+        this._merkleTree.update(index, identityCommitment)
+    }
+
+    /**
      * Removes a member from the group.
      * @param index Index of the member to be removed.
      */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,7 +2299,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@semaphore-protocol/group@workspace:packages/group"
   dependencies:
-    "@zk-kit/incremental-merkle-tree": 0.4.3
+    "@zk-kit/incremental-merkle-tree": 1.0.0
     circomlibjs: 0.0.8
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2
@@ -2861,6 +2861,13 @@ __metadata:
   version: 0.4.3
   resolution: "@zk-kit/incremental-merkle-tree@npm:0.4.3"
   checksum: 582ef97bd2b1b9638ce7c8a941200a5cf0ab86975f767de233905e8af0ff72d31b44f2497595f0ff585e45c7491481cf4e027ee6486a136cd64498d4b16b3e29
+  languageName: node
+  linkType: hard
+
+"@zk-kit/incremental-merkle-tree@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zk-kit/incremental-merkle-tree@npm:1.0.0"
+  checksum: 2b5d7b5cc08cf3aea536d6541a1177221fcacca5b93fb22e37cd05926d138fe69035b73cb42e09798505caf1b7a75ad225027d13d35c2f0d7b216147cafd184e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR update the `@zk-kit/incremental-merkle-tree` version and add an `update` method to the `Group` class to update the identity commitment of group members.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
